### PR TITLE
Feature/handle unsupported materials

### DIFF
--- a/Maya/Exporter/BabylonExporter.Texture.cs
+++ b/Maya/Exporter/BabylonExporter.Texture.cs
@@ -38,7 +38,7 @@ namespace Maya2Babylon
             MFnDependencyNode textureDependencyNode = getTextureDependencyNode(materialDependencyNode, plugName, textureModifiers);
 
 #region MantaLabs
-            // Check textureDependencyNode to see if type is layered texture
+            // Check textureDependencyNode if the type is a layered texture
             if (textureDependencyNode != null && textureDependencyNode.objectProperty.apiType == MFn.Type.kLayeredTexture)
             {
                 Print(textureDependencyNode, logRankTexture, "Print _ExportTexture is a layered texture");

--- a/Maya/Exporter/BabylonExporter.Texture.cs
+++ b/Maya/Exporter/BabylonExporter.Texture.cs
@@ -37,6 +37,31 @@ namespace Maya2Babylon
             List<MFnDependencyNode> textureModifiers = new List<MFnDependencyNode>();
             MFnDependencyNode textureDependencyNode = getTextureDependencyNode(materialDependencyNode, plugName, textureModifiers);
 
+#region MantaLabs
+            // Check textureDependencyNode to see if type is layered texture
+            if (textureDependencyNode != null && textureDependencyNode.objectProperty.apiType == MFn.Type.kLayeredTexture)
+            {
+                Print(textureDependencyNode, logRankTexture, "Print _ExportTexture is a layered texture");
+                // Get the number of connected children
+                MPlugArray connections = new MPlugArray();
+                textureDependencyNode.getConnections(connections);
+                int numChildren = connections.Count;
+                // Iterate over the children in reverse order, to get a valid texture at the bottom of the layer
+                for (int i = numChildren; i >= 0; --i)
+                {
+                    MPlug plug = connections[i];
+                    MObject connectedNode = plug.source.node;
+                    MFnDependencyNode childNode = new MFnDependencyNode(connectedNode);
+                    // Check if the child is a file texture
+                    if (childNode.objectProperty.apiType == MFn.Type.kFileTexture)
+                    {
+                        textureDependencyNode = childNode;
+                        break;
+                    }
+                }
+            }
+ #endregion MantaLabs
+
             return _ExportTexture(textureDependencyNode, babylonScene, textureModifiers, allowCube, forceAlpha, updateCoordinatesMode, amount);
         }
 

--- a/Maya/Exporter/BabylonExporter.Texture.cs
+++ b/Maya/Exporter/BabylonExporter.Texture.cs
@@ -47,7 +47,7 @@ namespace Maya2Babylon
                 textureDependencyNode.getConnections(connections);
                 int numChildren = connections.Count;
                 // Iterate over the children in reverse order, to get a valid texture at the bottom of the layer
-                for (int i = numChildren; i >= 0; --i)
+                for (int i = numChildren - 1; i >= 0; --i)
                 {
                     MPlug plug = connections[i];
                     MObject connectedNode = plug.source.node;


### PR DESCRIPTION
**Why**
The asset releases have layered textures for the bump material which are not supported by the exporter and would fail to export a normal map texture.

**How**
When we detect that the texture to export is `Type.kLayeredTexture` we check for the node's children and iterate starting from the last child that is of `MFn.Type.kFileTexture` and use that instead.