### PR TITLE
Feature/pbr materials extensions

### DIFF
--- a/Maya/Exporter/BabylonExporter.Material.cs
+++ b/Maya/Exporter/BabylonExporter.Material.cs
@@ -773,6 +773,26 @@ namespace Maya2Babylon
                 if (fullPBR)
                 {
                     var fullPBRMaterial = new BabylonPBRMaterial(babylonMaterial);
+
+                    // --- Transmission ---
+                    float transmissionWeight = materialDependencyNode.findPlug("transmission").asFloat();
+                    MFnDependencyNode transmissionTextureDependencyNode = getTextureDependencyNode(materialDependencyNode, "transmission");
+                    if (transmissionWeight > 0.0f || transmissionTextureDependencyNode != null)
+                    {
+                        fullPBRMaterial.subSurface.isRefractionEnabled = true;
+                        fullPBRMaterial.subSurface.refractionIntensityTexture = exportParameters.exportTextures ? ExportTexture(materialDependencyNode, "transmission", babylonScene) : null;
+                        if (fullPBRMaterial.subSurface.refractionIntensityTexture != null)
+                        {
+                            // When a texture is given, set the factor to 1.0
+                            fullPBRMaterial.subSurface.refractionIntensity = 1.0f;
+                        }
+                        else
+                        {
+                            // When no texture is given, apply the weight value to the factor
+                            fullPBRMaterial.subSurface.refractionIntensity = transmissionWeight;
+                        }
+                    }
+
                     babylonScene.MaterialsList.Add(fullPBRMaterial);
                 }
                 else

--- a/Maya/Exporter/BabylonExporter.Texture.cs
+++ b/Maya/Exporter/BabylonExporter.Texture.cs
@@ -40,7 +40,7 @@ namespace Maya2Babylon
             return _ExportTexture(textureDependencyNode, babylonScene, textureModifiers, allowCube, forceAlpha, updateCoordinatesMode, amount);
         }
 
-        private BabylonTexture _ExportTexture(MFnDependencyNode textureDependencyNode, BabylonScene babylonScene, List<MFnDependencyNode>  textureModifiers = null, bool allowCube = false, bool forceAlpha = false, bool updateCoordinatesMode = false, float amount = 1.0f)
+        private BabylonTexture _ExportTexture(MFnDependencyNode textureDependencyNode, BabylonScene babylonScene, List<MFnDependencyNode> textureModifiers = null, bool allowCube = false, bool forceAlpha = false, bool updateCoordinatesMode = false, float amount = 1.0f)
         {
             if (textureDependencyNode == null)
             {

--- a/Maya/Forms/ExporterForm.cs
+++ b/Maya/Forms/ExporterForm.cs
@@ -411,7 +411,7 @@ namespace Maya2Babylon.Forms
                     chkDracoCompression.Enabled = gltfPipelineInstalled;
                     chkNoAutoLight.Enabled = false;
                     chkNoAutoLight.Checked = true;
-                    chkFullPBR.Enabled = false;
+                    chkFullPBR.Enabled = true;
                     chkFullPBR.Checked = false;
                     chkDefaultSkybox.Enabled = false;
                     chkDefaultSkybox.Checked = false;
@@ -425,7 +425,7 @@ namespace Maya2Babylon.Forms
                     chkDracoCompression.Enabled = gltfPipelineInstalled;
                     chkNoAutoLight.Enabled = false;
                     chkNoAutoLight.Checked = true;
-                    chkFullPBR.Enabled = false;
+                    chkFullPBR.Enabled = true;
                     chkFullPBR.Checked = false;
                     chkDefaultSkybox.Enabled = false;
                     chkDefaultSkybox.Checked = false;

--- a/SharedProjects/Babylon2GLTF/GLTFExporter.Material.cs
+++ b/SharedProjects/Babylon2GLTF/GLTFExporter.Material.cs
@@ -600,7 +600,7 @@ namespace Babylon2GLTF
                     gltfMaterial.extensions = gltfMaterial.extensions ?? new GLTFExtensions(); // ensure extensions exist
                     gltfMaterial.extensions.AddExtension(gltf, "KHR_materials_specular", ext);
                 }
-                if (pbrMRMat.subSurface.isRefractionEnabled)
+                if (pbrMRMat.IsRefractionEnabled())
                 {
                     var s = pbrMRMat.subSurface;
                     var ext = new KHR_materials_transmission()

--- a/SharedProjects/BabylonExport.Entities/BabylonPBRMaterial.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonPBRMaterial.cs
@@ -264,6 +264,8 @@ namespace BabylonExport.Entities
             ambientTexture = origin.occlusionTexture;
             transparencyMode = origin.transparencyMode;
             wireframe = origin.wireframe;
+
+            subSurface = new BabylonPBRSubSurfaceConfiguration();
         }
         public BabylonPBRMaterial(BabylonPBRMetallicRoughnessMaterial origin) : this((BabylonPBRBaseSimpleMaterial)origin)
         {

--- a/SharedProjects/BabylonExport.Entities/BabylonPBRSubSurfaceConfiguration.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonPBRSubSurfaceConfiguration.cs
@@ -21,6 +21,5 @@ namespace BabylonExport.Entities
         public float tintColorAtDistance { get; set; }
         [DataMember]
         public float[] tintColor { get; set; }
-
     }
 }

--- a/SharedProjects/BabylonExport.Entities/Extensions/BabylonMaterialExtensions.cs
+++ b/SharedProjects/BabylonExport.Entities/Extensions/BabylonMaterialExtensions.cs
@@ -16,7 +16,8 @@ namespace BabylonExport.Entities
                     mat.metallicReflectanceTexture != null ||
                     mat.reflectanceTexture != null;
         }
-        public static bool IsVolumeEnabled(this BabylonPBRMaterial mat) => mat.subSurface.maximumThickness != null;
+        public static bool IsVolumeEnabled(this BabylonPBRMaterial mat) => mat.subSurface != null && mat.subSurface.maximumThickness != null;
         public static bool IsMetallicWorkflow(this BabylonPBRMaterial mat) => mat.metallic != null || mat.roughness != null || mat.metallicTexture != null;
+        public static bool IsRefractionEnabled(this BabylonPBRMaterial mat) => mat.subSurface != null && mat.subSurface.isRefractionEnabled;
     }
 }


### PR DESCRIPTION
**Why**
Several PBR material extensions such as `KHR_materials_transmission`, `KHR_materials_ior`, `KHR_materials_sheen` & `KHR_materials_specular` are not properly hooked up to export properties from Maya. Also running the FullBPR export flag would crash the exporter, this option is also disabled in the export gui.

**How**
First, had to enable and fix the crash with FullBPR exporting. Then handling the Maya material properties and assigning them to the Babylon Material for export according to the extension paramenters for `KHR_materials_transmission`, `KHR_materials_ior`, `KHR_materials_sheen` & `KHR_materials_specular`.